### PR TITLE
Prevent accessor collision with existing methods by directly creating a impl block

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,10 +319,6 @@ pub fn sort_by_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream
 /// assert_eq!(E::Variant1 { a: 0 }.a_big(), None);
 /// ```
 ///
-/// **Note**: this will create an extension trait `{TypeName}Accessor` ( i.e. the type `T` will get a new trait `TAccessor` ).
-/// This trait will have the same visibility as the type.
-/// When using this type from another module, make sure to bring the trait in scope with `use {TypeName}Accessor`.
-///
 /// #### Example
 ///
 /// Say we have a series of midi events, they are very similar but with slight variations - they always have some timing information but they may not always have a pitch or channel.


### PR DESCRIPTION
This should solve:
- #10 